### PR TITLE
replace references to jonabc org with github org

### DIFF
--- a/.github/workflows/licensed-ci.yml
+++ b/.github/workflows/licensed-ci.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby
-    - uses: jonabc/setup-licensed@v1
+    - uses: github/setup-licensed@v1
       with:
         version: '4.x'
 

--- a/.github/workflows/test-licenses.yml
+++ b/.github/workflows/test-licenses.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby
-    - uses: jonabc/setup-licensed@v1
+    - uses: github/setup-licensed@v1
       with:
         version: '4.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby
-    - uses: jonabc/setup-licensed@v1
+    - uses: github/setup-licensed@v1
       with:
         version: '4.x'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Contributing
 
-[fork]: https://github.com/jonabc/licensed-ci/fork
-[pr]: https://github.com/jonabc/licensed-ci/compare
-[style]: https://github.com/jonabc/licensed-ci/blob/main/.eslintrc.json
+[fork]: https://github.com/github/licensed-ci/fork
+[pr]: https://github.com/github/licensed-ci/compare
+[style]: https://github.com/github/licensed-ci/blob/main/.eslintrc.json
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # licensed-ci
 
-![test](https://github.com/jonabc/licensed-ci/workflows/Test/badge.svg)
+![test](https://github.com/github/licensed-ci/workflows/Test/badge.svg)
 
 Runs a [github/licensed](https://github.com/github/licensed) CI workflow.
 
@@ -111,13 +111,13 @@ jobs:
           bundler-cache: true # improve performance on subsequent runs
           cache-version: 1
       - run: xxx # Install project dependencies here.
-      - uses: jonabc/licensed-ci@v1
+      - uses: github/licensed-ci@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           command: "bundle exec licensed" # or bin/licensed when using binstubs
 ```
 
-### Basic non-Ruby usage using [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed)
+### Basic non-Ruby usage using [github/setup-licensed](https://github.com/github/setup-licensed)
 
 ```yaml
 jobs:
@@ -126,17 +126,17 @@ jobs:
       - uses: actions/checkout@v3
       
       # install licensed.  licensed v4 can only be installed as a gem and requires
-      # running ruby/setup-ruby before jonabc/setup-licensed.  If a project doesn't
+      # running ruby/setup-ruby before github/setup-licensed.  If a project doesn't
       # require a specific version of ruby, default to installing latest stable
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
-      - uses: jonabc/setup-licensed@v1
+      - uses: github/setup-licensed@v1
         with:
           version: 4.x
 
       - run: xxx # Install project dependencies here.
-      - uses: jonabc/licensed-ci@v1
+      - uses: github/licensed-ci@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -149,7 +149,7 @@ jobs:
     steps:
       - # environment setup ...
       - id: licensed # save the id of the step to reference later
-        uses: jonabc/licensed-ci@v1
+        uses: github/licensed-ci@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/github-script@0.2.0
@@ -217,17 +217,17 @@ jobs:
       - run: npm install --production --ignore-scripts
 
       # install licensed.  licensed v4 can only be installed as a gem and requires
-      # running ruby/setup-ruby before jonabc/setup-licensed.  If a project doesn't
+      # running ruby/setup-ruby before github/setup-licensed.  If a project doesn't
       # require a specific version of ruby, default to installing latest stable
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
-      - uses: jonabc/setup-licensed@v1
+      - uses: github/setup-licensed@v1
         with:
           version: 4.x
 
       - id: licensed
-        uses: jonabc/licensed-ci@v1
+        uses: github/licensed-ci@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/github-script@0.2.0

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jonabc/licensed-ci.git"
+    "url": "git+https://github.com/github/licensed-ci.git"
   },
   "keywords": [
     "GitHub",
@@ -20,9 +20,9 @@
   "author": "Jon Ruskin",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jonabc/licensed-ci/issues"
+    "url": "https://github.com/github/licensed-ci/issues"
   },
-  "homepage": "https://github.com/jonabc/licensed-ci#readme",
+  "homepage": "https://github.com/github/licensed-ci#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",

--- a/test/fixtures/testSearchResult.json
+++ b/test/fixtures/testSearchResult.json
@@ -3,12 +3,12 @@
   "incomplete_results": false,
   "items": [
     {
-      "url": "https://api.github.com/repos/jonabc/setup-licensed/issues/1",
-      "repository_url": "https://api.github.com/repos/jonabc/setup-licensed",
-      "labels_url": "https://api.github.com/repos/jonabc/setup-licensed/issues/1/labels{/name}",
-      "comments_url": "https://api.github.com/repos/jonabc/setup-licensed/issues/1/comments",
-      "events_url": "https://api.github.com/repos/jonabc/setup-licensed/issues/1/events",
-      "html_url": "https://github.com/jonabc/setup-licensed/pull/1",
+      "url": "https://api.github.com/repos/github/setup-licensed/issues/1",
+      "repository_url": "https://api.github.com/repos/github/setup-licensed",
+      "labels_url": "https://api.github.com/repos/github/setup-licensed/issues/1/labels{/name}",
+      "comments_url": "https://api.github.com/repos/github/setup-licensed/issues/1/comments",
+      "events_url": "https://api.github.com/repos/github/setup-licensed/issues/1/events",
+      "html_url": "https://github.com/github/setup-licensed/pull/1",
       "number": 1,
       "comments": 0,
       "state": "open",
@@ -16,10 +16,10 @@
       "updated_at": "2019-09-14T02:28:54Z",
       "closed_at": null,
       "pull_request": {
-        "url": "https://api.github.com/repos/jonabc/setup-licensed/pulls/1",
-        "html_url": "https://github.com/jonabc/setup-licensed/pull/1",
-        "diff_url": "https://github.com/jonabc/setup-licensed/pull/1.diff",
-        "patch_url": "https://github.com/jonabc/setup-licensed/pull/1.patch"
+        "url": "https://api.github.com/repos/github/setup-licensed/pulls/1",
+        "html_url": "https://github.com/github/setup-licensed/pull/1",
+        "diff_url": "https://github.com/github/setup-licensed/pull/1.diff",
+        "patch_url": "https://github.com/github/setup-licensed/pull/1.patch"
       }
     }
   ]

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,7 +12,7 @@ const processEnv = process.env;
 describe('configureGit', () => {
   beforeEach(() => {
     process.env.INPUT_GITHUB_TOKEN = 'token';
-    process.env.GITHUB_REPOSITORY = 'jonabc/licensed-ci';
+    process.env.GITHUB_REPOSITORY = 'github/licensed-ci';
     sinon.stub(core, 'group').callsFake((_name, fn) => fn());
   })
 
@@ -517,7 +517,7 @@ describe('findPullRequest', () => {
   let endpoint;
 
   beforeEach(() => {
-    process.env.GITHUB_REPOSITORY = 'jonabc/licensed-ci';
+    process.env.GITHUB_REPOSITORY = 'github/licensed-ci';
     endpoint = sinon.stub().resolves({ data: searchResultFixture });
     octokit = {
       rest: {
@@ -663,7 +663,7 @@ describe('newOctokit', () => {
       });
 
     const octokit = utils.newOctokit();
-    await octokit.rest.repos.get({ owner: 'jonabc', repo: 'licensed-ci' });
+    await octokit.rest.repos.get({ owner: 'github', repo: 'licensed-ci' });
     expect(authenticated).toEqual(true);
   });
 
@@ -672,13 +672,13 @@ describe('newOctokit', () => {
       .get(/.*/)
       .reply(403, 'rate limited', { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "1" })
       .get(/.*/)
-      .reply(200, { owner: 'jonabc', repo: 'licensed-ci' });
+      .reply(200, { owner: 'github', repo: 'licensed-ci' });
 
     
     const octokit = utils.newOctokit();
-    const response = await octokit.rest.repos.get({ owner: 'jonabc', repo: 'licensed-ci' });
+    const response = await octokit.rest.repos.get({ owner: 'github', repo: 'licensed-ci' });
     expect(response.status).toEqual(200);
-    expect(response.data).toEqual({ owner: 'jonabc', repo: 'licensed-ci' });
+    expect(response.data).toEqual({ owner: 'github', repo: 'licensed-ci' });
 
     expect(nockScope.isDone()).toEqual(true);
 

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -24,7 +24,7 @@ describe('branch workflow', () => {
 
   const pullRequest = require(path.normalize(path.join(__dirname, '..', 'fixtures', 'pullRequest.json')));
 
-  const owner = 'jonabc';
+  const owner = 'github';
   const repo = 'licensed-ci';
   const userConfig = ['-c', 'config=value'];
 

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -21,7 +21,7 @@ describe('push workflow', () => {
   const localBranch = `${utils.getOrigin()}/${branch}`;
 
   // to match the response from the testSearchResult.json fixture
-  const owner = 'jonabc';
+  const owner = 'github';
   const repo = 'setup-licensed';
   const userConfig = ['-c', 'config=value'];
 


### PR DESCRIPTION
### Description

With the transfer of this repository from `jonabc` org to `github` org, the URLs referencing the action and the statements using the action needed to be updated.  This PR updates those org references.